### PR TITLE
Fix getting started

### DIFF
--- a/docs/guide/context.md
+++ b/docs/guide/context.md
@@ -89,7 +89,7 @@ The Mali Response object.
 ### ctx.req
 
 The request object. This is alias for `ctx.request.req`.
-In case of `UNIRY` and `RESPONSE_STREAM` calls it is simply the gRPC `call`'s `request`. 
+In case of `UNARY` and `RESPONSE_STREAM` calls it is simply the gRPC `call`'s `request`. 
 In case of `REQUEST_STREAM` and `DUPLEX` calls it's the gRPC `call` reference itself.
 
 ```js
@@ -100,7 +100,7 @@ console.log(ctx.req) // { name: 'Bob' }
 
 The response object. This is an alias to `ctx.response.res`.
 This is set only in case of `DUPLEX` calls, to the the gRPC `call` reference itself.
-In all other cases set the `res` property to the actual response message / object in case of `UNIRY` and `REQUEST_STREAM` calls, and to the output stream in case of `RESPONSE_STREAM` calls. 
+In all other cases set the `res` property to the actual response message / object in case of `UNARY` and `REQUEST_STREAM` calls, and to the output stream in case of `RESPONSE_STREAM` calls. 
 When a stream it is automatically [piped](https://nodejs.org/api/stream.html#stream_event_pipe) into the call.
 
 ```js

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -54,7 +54,7 @@ and the name of the service constrcutor.
 
 ```js
 const services = require('./static/helloworld_grpc_pb')
-const app = new Mali(services, 'GreeterService')
+const app = new Mali(services, 'Greeter')
 ```
 
 ### Handling request

--- a/docs/guide/request.md
+++ b/docs/guide/request.md
@@ -26,7 +26,7 @@ The internal gRPC call instance reference.
 ### request.req
 
 The actuall call request object.
-In case of `UNIRY` and `RESPONSE_STREAM` calls it is simply the gRPC `call`'s `request`. 
+In case of `UNARY` and `RESPONSE_STREAM` calls it is simply the gRPC `call`'s `request`. 
 In case of `REQUEST_STREAM` and `DUPLEX` calls it's the gRPC `call` reference itself.
 
 ```js

--- a/docs/guide/response.md
+++ b/docs/guide/response.md
@@ -55,7 +55,7 @@ console.log(ctx.response.status)  // { biz: 'baz' }
 
 The actual call response payload object.
 This is set only in case of `DUPLEX` calls, to the the gRPC `call` reference itself.
-In all other cases set the `res` property to the actual response message / object in case of `UNIRY` and `REQUEST_STREAM` calls, and to the output stream in case of `RESPONSE_STREAM` calls. 
+In all other cases set the `res` property to the actual response message / object in case of `UNARY` and `REQUEST_STREAM` calls, and to the output stream in case of `RESPONSE_STREAM` calls. 
 When a stream it is automatically [piped](https://nodejs.org/api/stream.html#stream_event_pipe) into the call.
 
 ```js


### PR DESCRIPTION
Hello @anonrig 

This PR fixes the code sample in the "Getting Started" page. It also corrects the spelling of "unary".

Thank you.